### PR TITLE
implemeted actual url for build, only supports team=main

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -82,7 +82,7 @@ func Put(req Request) error {
 		Key:         os.Getenv("BUILD_JOB_NAME"),
 		Name:        fmt.Sprintf("%s-%s", os.Getenv("BUILD_JOB_NAME"), os.Getenv("BUILD_ID")),
 		Description: req.Params.Description,
-		URL:         os.Getenv("ATC_EXTERNAL_URL"),
+		URL:         getBuildURL(),
 	}
 
 	Log("Build status %#v\n", status)
@@ -106,4 +106,13 @@ func Put(req Request) error {
 	}
 
 	return Output(result)
+}
+
+func getBuildURL() string {
+	atc := os.Getenv("ATC_EXTERNAL_URL")
+	team := "main" // hard-coded until https://github.com/concourse/concourse/issues/616 is resolved
+	pipeline := os.Getenv("BUILD_PIPELINE_NAME")
+	job := os.Getenv("BUILD_JOB_NAME")
+	build := os.Getenv("BUILD_NAME")
+	return fmt.Sprintf(`%s/%s/pipelines/%s/jobs/%s/builds/%s`, atc, team, pipeline, job, build)
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -114,5 +114,5 @@ func getBuildURL() string {
 	pipeline := os.Getenv("BUILD_PIPELINE_NAME")
 	job := os.Getenv("BUILD_JOB_NAME")
 	build := os.Getenv("BUILD_NAME")
-	return fmt.Sprintf(`%s/%s/pipelines/%s/jobs/%s/builds/%s`, atc, team, pipeline, job, build)
+	return fmt.Sprintf(`%s/teams/%s/pipelines/%s/jobs/%s/builds/%s`, atc, team, pipeline, job, build)
 }


### PR DESCRIPTION
I updated the build-status to have the proper URL link. However, only `main` team is supported, while we await https://github.com/concourse/concourse/issues/616. 
