### PR TITLE
Allow option to skip SSL verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ A concourse resource that will set a build status on your commits.
   Using basic auth without SSL may cause an issue with the stash API where a retry
   needed.
 
+* `skip_ssl_verification`: *Optional.* Skip verifying the SSL certificate of the
+  Stash server. Defaults to `false`.
+
 ### Example
 
 ```yaml

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Source struct {
-	Host          string `json:"host"`
-	Username      string `json:"username"`
-	Password      string `json:"password"`
-	RetryAttempts int    `json:"retry_attempts"`
+	Host                string `json:"host"`
+	Username            string `json:"username"`
+	Password            string `json:"password"`
+	RetryAttempts       int    `json:"retry_attempts"`
+	SkipSSLVerification bool   `json:"skip_ssl_verification"`
 }
 
 type Version struct {
@@ -67,7 +68,7 @@ func Output(v interface{}) error {
 
 func Put(req Request) error {
 	src := req.Source
-	client := NewStashClient(src.Host, src.Username, src.Password)
+	client := NewStashClient(src.Host, src.Username, src.Password, src.SkipSSLVerification)
 
 	cmd := exec.Command("git", "rev-parse", "--short=40", "HEAD")
 	cmd.Dir = fmt.Sprintf("%s/%s", os.Args[1], req.Params.Repository)


### PR DESCRIPTION
Expose an option to skip SSL verification of the Stash server. Useful for Stash servers with self-signed certificates.